### PR TITLE
Feature/nested starting style

### DIFF
--- a/.changeset/brown-onions-relate.md
+++ b/.changeset/brown-onions-relate.md
@@ -1,0 +1,5 @@
+---
+"rrweb-cssom": patch
+---
+
+fix parsing errors for nested starting-style rules

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -181,7 +181,7 @@ CSSOM.parse = function parse(token) {
 				break;
 			} else if (token.indexOf("@starting-style", i) === i) {
 				state = "startingStyleRule-begin";
-				i += "startingStyle".length;
+				i += "starting-style".length;
 				startingStyleRule = new CSSOM.CSSStartingStyleRule();
 				startingStyleRule.__starts = i;
 				buffer = "";
@@ -430,6 +430,7 @@ CSSOM.parse = function parse(token) {
 							parentRule.constructor.name === "CSSMediaRule"
 							|| parentRule.constructor.name === "CSSSupportsRule"
 							|| parentRule.constructor.name === "CSSContainerRule"
+							|| parentRule.constructor.name === "CSSStartingStyleRule"
 						) {
 							prevScope = currentScope;
 							currentScope = parentRule;

--- a/spec/parse.spec.js
+++ b/spec/parse.spec.js
@@ -1000,6 +1000,80 @@ var TESTS = [
 		})()
 	},
 	{
+		input: "@starting-style { @media screen { body { background: red; } } }",
+		result: (function() {
+			var result = {
+				cssRules: [
+				{
+					cssRules: {
+						0: {
+							cssRules: {
+								0: {
+									parentRule: "../..",
+									parentStyleSheet: "../../../../../..",
+									selectorText: "body",
+									style: {
+										0: "background",
+										length: 1,
+										parentRule: "..",
+										background: "red",
+									},
+								},
+							},
+							parentRule: null,
+							media: {
+								0: "screen",
+								length: 1
+							}
+						},
+					},
+					parentRule: null,
+				},
+				],
+				parentStyleSheet: null,
+			};
+			result.cssRules[0].parentStyleSheet = result.cssRules[0].cssRules[0].parentStyleSheet = result;
+			return result;
+		})()
+	},
+	{
+		input: "@media screen { @starting-style { body { background: red; } } }",
+		result: (function() {
+			var result = {
+				cssRules: [
+				{
+					cssRules: {
+					0: {
+						cssRules: {
+							0: {
+								parentRule: "../..",
+								parentStyleSheet: "../../../../../..",
+								selectorText: "body",
+								style: {
+									0: "background",
+									length: 1,
+									parentRule: "..",
+									background: "red",
+								},
+							},
+						},
+						parentRule: null,
+					},
+				},
+            parentRule: null,
+			media: {
+				0: "screen",
+				length: 1
+			}
+          },
+        ],
+        parentStyleSheet: null,
+      };
+			result.cssRules[0].parentStyleSheet = result.cssRules[0].cssRules[0].parentStyleSheet = result;
+			return result;
+		})()
+	},
+	{
 		// Non-vendor prefixed @keyframes rule, from Twitter Bootstrap (progress-bars):
 		input: '@keyframes progress-bar-stripes {\n  from  { background-position: 0 0; }\n  to    { background-position: 40px 0; }\n}',
 		result: (function () {


### PR DESCRIPTION
my last pr missed the case for nested `@starting-style` rules

for example:

`@starting-style { @media (max-width:991px) { .demo { background-color: #f00; } } }`

and

`@media (max-width:991px) { @starting-style  { .demo { background-color: #f00; } } }`