### PR TITLE
fix: check the priority value of the existing property

### DIFF
--- a/lib/CSSStyleDeclaration.js
+++ b/lib/CSSStyleDeclaration.js
@@ -46,13 +46,24 @@ CSSOM.CSSStyleDeclaration.prototype = {
 				this[this.length] = name;
 				this.length++;
 			}
+	
+			// If the priority value of the incoming property is "important",
+			// or the value of the existing property is not "important", 
+			// then remove the existing property and rewrite it.
+			if (priority || !this._importants[name]) {
+				this.removeProperty(name);
+				this[this.length] = name;
+				this.length++;
+				this[name] = value + '';
+				this._importants[name] = priority;
+			}
 		} else {
 			// New property.
 			this[this.length] = name;
 			this.length++;
+			this[name] = value + '';
+			this._importants[name] = priority;
 		}
-		this[name] = value + "";
-		this._importants[name] = priority;
 	},
 
 	/**


### PR DESCRIPTION
 Should check the priority value of the existing property.

 e.g. 
 ``` css
{ color: white!important; color: black; }
```

 the property `color` already exists, but it's `"important",` should not be overwritten by the new value `black` .